### PR TITLE
Patch update for newest release

### DIFF
--- a/vainglory.json
+++ b/vainglory.json
@@ -129,10 +129,10 @@
 				"crystal_lifesteal" :   false
 			},
 			"tip" : "Helps you deal consistent damage after you've built enough crystal power.",
-			"build_from" : {
-				"path_1" : ["heavy_crystal"],
-				"path_2" : ["blazing_salvo"]
-			},
+			"build_from" : [
+				"heavy_prism",
+				"blazing_salvo"
+			],
 			"builds_to" : false
 		},
 		"atlas_pauldron" : {
@@ -269,10 +269,12 @@
 				"swift_shooter"
 			],
 			"builds_to" : [
+				"alternating_current",
 				"poisoned_shiv",
 				"breaking_point",
 				"bonesaw",
-				"tornado_trigger"
+				"tornado_trigger",
+				"shiversteel"
 			]
 		},
 		"bonesaw" : {
@@ -403,10 +405,11 @@
 				"crystal_lifesteal" :   false
 			},
 			"tip" : "Helps you stay healthy while last-hitting in lane.",
-			"build_from" : false,
-			"builds_to" : [
-				"barbed_needle"
-			]
+			"build_from" : [
+				"heavy_steel",
+				"blazing_salvo"
+			],
+			"builds_to" : false
 		},
 		"broken_myth" : {
 			"name" : "Broken Myth",
@@ -510,8 +513,8 @@
 			"category" : "Crystal",
 			"tier" : 3,
 			"cost" : 2400,
-			"activate" : "Upon damaging an enemy hero with an ability, reduce all cooldowns by 6%. This can only occur once every 2s.",
-			"passive" : false,
+			"activate" : false,
+			"passive" : "Upon damaging an enemy hero with an ability, reduce all cooldowns by 6%. This can only occur once every 2s.",
 			"vampirism" : false,
 			"bookofeulogies" : false,
 			"armorbreaker" : false,
@@ -2172,7 +2175,7 @@
 				"crystal_bit"
 			],
 			"builds_to" : [
-				"borken_myth"
+				"broken_myth"
 			]
 		},
 		"piercing_spear" : {
@@ -2306,12 +2309,8 @@
 				"crystal_lifesteal" :   false
 			},
 			"tip" : "Purchase this if you expect heavy aggression coming from the enemy team or want early teamfights.",
-			"build_from" : [
-				"template_item"
-			],
-			"builds_to" : [
-				"template_item"
-			]
+			"build_from" : false,
+			"builds_to" : false
 		},
 		"reflex_block" : {
 			"name" : "Reflex Block",
@@ -2403,7 +2402,7 @@
 				"hourglass"
 			],
 			"builds_to" : [
-				"superscout2000"
+				"superscout_2000"
 			]
 		},
 		"scout_trap" : {
@@ -2491,7 +2490,7 @@
 				"flare_loader"
 			],
 			"builds_to" : [
-				"superscout2000"
+				"superscout_2000"
 			]
 		},
 		"serpent_mask" : {
@@ -2625,7 +2624,7 @@
 			"tip" : "Use this to slow fleeing enemies.",
 			"build_from" : [
 				"blazing_salvo",
-				"dragon_heart"
+				"dragonheart"
 			],
 			"builds_to" : false
 		},
@@ -2990,7 +2989,7 @@
 				"stormcrown"
 			]
 		},
-		"superscout2000" : {
+		"superscout_2000" : {
 			"name" : "SuperScout 2000",
 			"thumb" : "superscout-2000.png",
 			"category" : "Other",
@@ -3074,11 +3073,9 @@
 				"crystal_lifesteal" :   false
 			},
 			"tip" : false,
-			"build_from" : [
-				"template_item"
-			],
+			"build_from" : false,
 			"builds_to" : [
-				"template_item"
+				"blazing_salvo"
 			]
 		},
 		"teleport_boots" : {


### PR DESCRIPTION
Tasks done for next GitHub update:
  * fixed inconsistency with item "superscout2000" (the key now has an underscore which is more consistant with naming convention changes throughout the data containing spaces)
  * fixed mistake where the "clockwork" item had it's passive aspect marked as an activate aspect
  * fixed mistake where "swift_shooter" had placeholder data for "builds_to" and "build_from" data values
  * fixed type-o in "shiversteel" "build_from" where the dragonheart value incorrectly had an underscore
  * added "shiversteel" to the "blazing_salvo" object's "builds_to" array
  * fixed mistake with "alternating_current" object's "builds_to" and "build_from" structure and values
  * fixed "breaking_point" object's "builds_to" and "build_from" values
  * fixed type-o in "piercing_shard" object, where "builds_to" value was missspelled
  * fixed mistake with "protector_contract" object's "builds_to" and "build_from" structure and values