### PR TITLE
Update for patch 3.5!

### DIFF
--- a/vainglory.json
+++ b/vainglory.json
@@ -1,5 +1,5 @@
 {
-	"version" : "3.4.1.2",
+	"version" : "3.5.1.0",
 	"items" : {
 		"aegis" : {
 			"name" : "Aegis",
@@ -76,7 +76,7 @@
 				"range" :               false,
 				"move_speed" :          false,
 				"energy_recharge" :     { "value" : 2.5, "name" : "Energy Recharge", "units" : false },
-				"cooldown" :            { "value" : 15, "name" : "Cooldown Speed", "units" : "%" },
+				"cooldown" :            { "value" : 15, "name" : "Cooldown Reduction", "units" : "%" },
 				"crit_chance" :         false,
 				"crit_damage" :         false,
 				"armor_pierce" :        false,
@@ -332,7 +332,7 @@
 			"activate" : false,
 			"passive" : false,
 			"vampirism" : "+4% lifesteal (does not stack with other Vampirism)",
-			"bookofeulogies" : "Restores 25 health whenever you kill a minion or monster (60 if using a melee default attack).",
+			"bookofeulogies" : "Restores 25 health whenever you kill a minion or monster (65 if using a melee default attack).",
 			"armorbreaker" : false,
 			"shieldbreaker" : false,
 			"consume" : false,
@@ -464,7 +464,7 @@
 			"tier" : 3,
 			"cost" : 2100,
 			"activate" : false,
-			"passive" : "Your heals and barriers are 20% stronger. Also, Capacitor Plate lets your heals and barriers also grant other allied heroes bonus move speed for 2s. (10s cooldown per hero)",
+			"passive" : "Your heals and barriers are 15% stronger. Also, Capacitor Plate lets your heals and barriers also grant other allied heroes bonus move speed for 2s. (10s cooldown per hero)",
 			"vampirism" : false,
 			"bookofeulogies" : false,
 			"armorbreaker" : false,
@@ -487,7 +487,7 @@
 				"range" :               false,
 				"move_speed" :          false,
 				"energy_recharge" :     { "value" : 2.5, "name" : "Energy Recharge", "units" : false },
-				"cooldown" :            { "value" : 15, "name" : "Cooldown Speed", "units" : "%" },
+				"cooldown" :            { "value" : 15, "name" : "Cooldown Reduction", "units" : "%" },
 				"crit_chance" :         false,
 				"crit_damage" :         false,
 				"armor_pierce" :        false,
@@ -532,7 +532,7 @@
 				"range" :               false,
 				"move_speed" :          false,
 				"energy_recharge" :     { "value" : 2.5, "name" : "Energy Recharge", "units" : false },
-				"cooldown" :            { "value" : 10, "name" : "Cooldown Speed", "units" : "%" },
+				"cooldown" :            { "value" : 10, "name" : "Cooldown Reduction", "units" : "%" },
 				"crit_chance" :         false,
 				"crit_damage" :         false,
 				"armor_pierce" :        false,
@@ -585,7 +585,7 @@
 				"range" :               false,
 				"move_speed" :          false,
 				"energy_recharge" :     { "value" : 10, "name" : "Energy Recharge", "units" : false },
-				"cooldown" :            { "value" : 20, "name" : "Cooldown Speed", "units" : "%" },
+				"cooldown" :            { "value" : 20, "name" : "Cooldown Reduction", "units" : "%" },
 				"crit_chance" :         false,
 				"crit_damage" :         false,
 				"armor_pierce" :        false,
@@ -643,6 +643,7 @@
 				"light_armor"
 			],
 			"builds_to" : [
+				"slumbering_husk",
 				"metal_jacket",
 				"atlas_pauldron"
 			]
@@ -677,7 +678,7 @@
 				"range" :               false,
 				"move_speed" :          false,
 				"energy_recharge" :     { "value" : 30, "name" : "Energy Recharge", "units" : false },
-				"cooldown" :            { "value" : 20, "name" : "Cooldown Speed", "units" : "%" },
+				"cooldown" :            { "value" : 20, "name" : "Cooldown Reduction", "units" : "%" },
 				"crit_chance" :         false,
 				"crit_damage" :         false,
 				"armor_pierce" :        false,
@@ -1086,7 +1087,7 @@
 				"health_recharge" :     false,
 				"energy" :              { "value" : 400, "name" : "Max Energy", "units" : false },
 				"weapon_power" :        false,
-				"crystal_power" :       { "value" : 55, "name" : "Crystal Power", "units" : false },
+				"crystal_power" :       { "value" : 70, "name" : "Crystal Power", "units" : false },
 				"attack_speed" :        false,
 				"armor" :               false,
 				"shield" :              false,
@@ -1360,7 +1361,7 @@
 				"range" :               false,
 				"move_speed" :          { "value" : 0.4, "name" : "Move Speed", "units" : "m/s" },
 				"energy_recharge" :     { "value" : 6, "name" : "Energy Recharge", "units" : false },
-				"cooldown" :            { "value" : 10, "name" : "Cooldown Speed", "units" : "%" },
+				"cooldown" :            { "value" : 10, "name" : "Cooldown Reduction", "units" : "%" },
 				"crit_chance" :         false,
 				"crit_damage" :         false,
 				"armor_pierce" :        false,
@@ -1548,7 +1549,7 @@
 				"range" :               false,
 				"move_speed" :          false,
 				"energy_recharge" :     { "value" : 1.5, "name" : "Energy Recharge", "units" : false },
-				"cooldown" :            { "value" : 5, "name" : "Cooldown Speed", "units" : "%" },
+				"cooldown" :            { "value" : 5, "name" : "Cooldown Reduction", "units" : "%" },
 				"crit_chance" :         false,
 				"crit_damage" :         false,
 				"armor_pierce" :        false,
@@ -1692,7 +1693,8 @@
 			],
 			"builds_to" : [
 				"fountain_of_renewal",
-				"aegis"
+				"aegis",
+				"slumbering_husk"
 			]
 		},
 		"level_juice" : {
@@ -1789,7 +1791,7 @@
 			"thumb" : "light-armor.png",
 			"category" : "Defense",
 			"tier" : 1,
-			"cost" : 250,
+			"cost" : 300,
 			"activate" : false,
 			"passive" : false,
 			"vampirism" : false,
@@ -1809,7 +1811,7 @@
 				"weapon_power" :        false,
 				"crystal_power" :       false,
 				"attack_speed" :        false,
-				"armor" :               { "value" : 30, "name" : "Armor", "units" : false },
+				"armor" :               { "value" : 35, "name" : "Armor", "units" : false },
 				"shield" :              { "value" : 5, "name" : "Shield", "units" : false },
 				"range" :               false,
 				"move_speed" :          false,
@@ -1833,7 +1835,7 @@
 			"thumb" : "light-shield.png",
 			"category" : "Defense",
 			"tier" : 1,
-			"cost" : 250,
+			"cost" : 300,
 			"activate" : false,
 			"passive" : false,
 			"vampirism" : false,
@@ -1853,8 +1855,8 @@
 				"weapon_power" :        false,
 				"crystal_power" :       false,
 				"attack_speed" :        false,
-				"armor" :               false,
-				"shield" :              false,
+				"armor" :               { "value" : 5, "name" : "Armor", "units" : false },
+				"shield" :              { "value" : 35, "name" : "Shield", "units" : false },
 				"range" :               false,
 				"move_speed" :          false,
 				"energy_recharge" :     false,
@@ -1903,8 +1905,8 @@
 				"move_speed" :          false,
 				"energy_recharge" :     false,
 				"cooldown" :            false,
-				"crit_chance" :         { "value" : 20, "name" : "Critical Hit Chance", "units" : "%" },
-				"crit_damage" :         { "value" : 8, "name" : "Critical Hit Damage", "units" : "%" },
+				"crit_chance" :         { "value" : 25, "name" : "Critical Hit Chance", "units" : "%" },
+				"crit_damage" :         { "value" : 5, "name" : "Critical Hit Damage", "units" : "%" },
 				"armor_pierce" :        false,
 				"shield_pierce" :       false,
 				"weapon_lifesteal" :    false,
@@ -2079,7 +2081,7 @@
 				"range" :               false,
 				"move_speed" :          false,
 				"energy_recharge" :     { "value" : 4, "name" : "Energy Recharge", "units" : false },
-				"cooldown" :            { "value" : 15, "name" : "Cooldown Speed", "units" : "%" },
+				"cooldown" :            { "value" : 15, "name" : "Cooldown Reduction", "units" : "%" },
 				"crit_chance" :         false,
 				"crit_damage" :         false,
 				"armor_pierce" :        false,
@@ -2255,7 +2257,7 @@
 				"health" :              false,
 				"health_recharge" :     false,
 				"energy" :              false,
-				"weapon_power" :        { "value" : 40, "name" : "Weapon Power", "units" : false },
+				"weapon_power" :        { "value" : 30, "name" : "Weapon Power", "units" : false },
 				"crystal_power" :       false,
 				"attack_speed" :        { "value" : 25, "name" : "Attack Speed", "units" : "%" },
 				"armor" :               false,
@@ -2327,7 +2329,7 @@
 			"tier" : 3,
 			"cost" : 2000,
 			"activate" : false,
-			"passive" : "Upon taking damage from an enemy hero, gain bonus move speed for 3s then deal 200 (+15% of bonus health) damage and slow nearby enemies by 25% (+0.015% of bonus health) for 2s. (30s cooldown). Pulseweave also adds +10% base move speed. Pulseweave also has the passive of Lifespring.",
+			"passive" : "Upon taking damage from an enemy hero, gain bonus move speed for 3s then deal 200 (+15% of bonus health) damage and slow nearby enemies by 20% (+0.01% of bonus health) for 2s. (30s cooldown). Pulseweave also adds +10% base move speed. Pulseweave also has the passive of Lifespring.",
 			"vampirism" : false,
 			"bookofeulogies" : false,
 			"armorbreaker" : false,
@@ -2442,7 +2444,7 @@
 				"range" :               false,
 				"move_speed" :          false,
 				"energy_recharge" :     { "value" : 2.5, "name" : "Energy Recharge", "units" : false },
-				"cooldown" :            { "value" : 15, "name" : "Cooldown Speed", "units" : "%" },
+				"cooldown" :            { "value" : 15, "name" : "Cooldown Reduction", "units" : "%" },
 				"crit_chance" :         false,
 				"crit_damage" :         false,
 				"armor_pierce" :        false,
@@ -2487,7 +2489,7 @@
 				"range" :               false,
 				"move_speed" :          false,
 				"energy_recharge" :     { "value" : 2.5, "name" : "Energy Recharge", "units" : false },
-				"cooldown" :            { "value" : 10, "name" : "Cooldown Speed", "units" : "%" },
+				"cooldown" :            { "value" : 10, "name" : "Cooldown Reduction", "units" : "%" },
 				"crit_chance" :         false,
 				"crit_damage" :         false,
 				"armor_pierce" :        false,
@@ -2871,7 +2873,7 @@
 			"tier" : 3,
 			"cost" : 2700,
 			"activate" : false,
-			"passive" : "Abilities dealing crystal damage to enemies (excluding lane minions) deal 8-30 (level 1-12) +100% of your crystal power as bonus crystal damage over 3s and apply Mortal Wounds for the duration.",
+			"passive" : "Abilities dealing crystal damage to enemies (excluding lane minions) deal 5-20 (level 1-12) +100% of your crystal power as bonus crystal damage over 3s and apply Mortal Wounds for the duration.",
 			"vampirism" : false,
 			"bookofeulogies" : false,
 			"armorbreaker" : false,
@@ -2938,7 +2940,7 @@
 				"range" :               false,
 				"move_speed" :          false,
 				"energy_recharge" :     { "value" : 3, "name" : "Energy Recharge", "units" : false },
-				"cooldown" :            { "value" : 20, "name" : "Cooldown Speed", "units" : "%" },
+				"cooldown" :            { "value" : 20, "name" : "Cooldown Reduction", "units" : "%" },
 				"crit_chance" :         false,
 				"crit_damage" :         false,
 				"armor_pierce" :        false,
@@ -3027,7 +3029,7 @@
 				"range" :               false,
 				"move_speed" :          false,
 				"energy_recharge" :     { "value" : 4, "name" : "Energy Recharge", "units" : false },
-				"cooldown" :            { "value" : 20, "name" : "Cooldown Speed", "units" : "%" },
+				"cooldown" :            { "value" : 20, "name" : "Cooldown Reduction", "units" : "%" },
 				"crit_chance" :         false,
 				"crit_damage" :         false,
 				"armor_pierce" :        false,
@@ -3118,7 +3120,7 @@
 				"range" :               false,
 				"move_speed" :          false,
 				"energy_recharge" :     { "value" : 5, "name" : "Energy Recharge", "units" : false },
-				"cooldown" :            { "value" : 25, "name" : "Cooldown Speed", "units" : "%" },
+				"cooldown" :            { "value" : 25, "name" : "Cooldown Reduction", "units" : "%" },
 				"crit_chance" :         false,
 				"crit_damage" :         false,
 				"armor_pierce" :        false,
@@ -3290,7 +3292,7 @@
 				"energy" :              false,
 				"weapon_power" :        false,
 				"crystal_power" :       false,
-				"attack_speed" :        { "value" : 40, "name" : "Attack Speed", "units" : "%" },
+				"attack_speed" :        { "value" : 30, "name" : "Attack Speed", "units" : "%" },
 				"armor" :               false,
 				"shield" :              false,
 				"range" :               false,
@@ -3298,7 +3300,7 @@
 				"energy_recharge" :     false,
 				"cooldown" :            false,
 				"crit_chance" :         { "value" : 35, "name" : "Critical Hit Chance", "units" : "%" },
-				"crit_damage" :         false,
+				"crit_damage" :         { "value" : 5, "name" : "Critical Hit Damage", "units" : "%" },
 				"armor_pierce" :        false,
 				"shield_pierce" :       false,
 				"weapon_lifesteal" :    false,
@@ -3668,7 +3670,7 @@
 					"level_gain" : 0.23
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -3731,7 +3733,7 @@
 						"Arcane Fire (status effect): Burns the target every second and causes Adagio's other abilities to deal more damage.",
 						[
 							"Burst heals the target instantly, followed by a gradual heal over the next few seconds.",
-							"Burst Heal is increased by 12% of Adagio's bonus health.",
+							"Burst Heal is increased by 9% of Adagio's bonus health.",
 							"When cast on self, slows nearby enemies by 70% for 0.7s.",
 							"Resets basic-attack cooldown on activation."
 						]
@@ -3751,16 +3753,16 @@
 							"overdrive" : false
 						},
 						{
-							"name" : "Fire Duration",
+							"name" : "Fire Duration (s)",
 							"values" : [5, 5.5, 6, 6.5, 7],
 							"ratios" : [0, 0],
 							"overdrive" : false
 						},
 						{
-							"name" : "Fire Damage",
-							"values" : [20, 30, 40, 50, 70],
-							"ratios" : [20, 0],
-							"overdrive" : 70
+							"name" : "Fire Damage / Sec",
+							"values" : [10, 20, 30, 40, 60],
+							"ratios" : [25, 0],
+							"overdrive" : 60
 						},
 						{
 							"name" : "Heal Duration",
@@ -3943,8 +3945,8 @@
 					"name" : "Health",
 					"units" : false,
 					"min" : 761,
-					"max" : 2438,
-					"level_gain" : 152.45
+					"max" : 2537,
+					"level_gain" : 161.45
 				},
 				"health_recharge" : {
 					"name" : "Health Recharge",
@@ -3973,8 +3975,8 @@
 					"name" : "Attack Speed",
 					"units" : "%",
 					"min" : 100,
-					"max" : 122,
-					"level_gain" : 2
+					"max" : 136.3,
+					"level_gain" : 3.3
 				},
 				"armor" : {
 					"name" : "Armor",
@@ -4005,7 +4007,7 @@
 					"level_gain" : 0
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -4249,6 +4251,292 @@
 				}
 			]
 		},
+		"anka" : {
+			"name" : "Anka",
+			"thumb" : "anka.png",
+			"difficulty" : "Hard",
+			"attack_type" : "Melee",
+			"description" : "Elusive assassin with tremendous burst potential",
+			"primary_role" : "Laner",
+			"ratings" : {
+				"offense" : 10,
+				"defense" : 2,
+				"team_utility" : 1,
+				"mobility" : 7
+			},
+			"stats" : {
+				"health" : {
+					"name" : "Health",
+					"units" : false,
+					"min" : 750,
+					"max" : 2301,
+					"level_gain" : 141
+				},
+				"health_recharge" : {
+					"name" : "Health Recharge",
+					"units" : false,
+					"min" : 0,
+					"max" : 0,
+					"level_gain" : 0
+				},
+				"weapon_power" : {
+					"name" : "Weapon Power",
+					"units" : false,
+					"wp_scaling" : 0,
+					"min" : 82,
+					"max" : 152,
+					"level_gain" : 6.36
+				},
+				"crystal_power" : {
+					"name" : "Crystal Power",
+					"units" : false,
+					"cp_scaling" : 0,
+					"min" : 0,
+					"max" : 0,
+					"level_gain" : 0
+				},
+				"attack_speed" : {
+					"name" : "Attack Speed",
+					"units" : "%",
+					"min" : 100,
+					"max" : 136.3,
+					"level_gain" : 3.3
+				},
+				"armor" : {
+					"name" : "Armor",
+					"units" : false,
+					"min" : 20,
+					"max" : 60,
+					"level_gain" : 3.63
+				},
+				"shield" : {
+					"name" : "Shield",
+					"units" : false,
+					"min" : 20,
+					"max" : 60,
+					"level_gain" : 3.63
+				},
+				"energy" : {
+					"name" : "Energy",
+					"units" : false,
+					"min" : 200,
+					"max" : 695,
+					"level_gain" : 45
+				},
+				"energy_recharge" : {
+					"name" : "Energy Recharge",
+					"units" : false,
+					"min" : 0,
+					"max" : 0,
+					"level_gain" : 0
+				},
+				"cooldown" : {
+					"name" : "Cooldown Reduction",
+					"units" : "%",
+					"min" : 100
+				},
+				"range" : {
+					"name" : "Range",
+					"units" : "m",
+					"min" : 1.6
+				},
+				"move_speed" : {
+					"name" : "Move Speed",
+					"units" : "m/s",
+					"min" : 3.6
+				},
+				"crit_chance" : {
+					"name" : "Critical Hit Chance",
+					"units" : "%",
+					"min" : 0
+				},
+				"crit_damage" : {
+					"name" : "Critical Hit Damage",
+					"units" : "%",
+					"min" : 150
+				},
+				"armor_pierce" : {
+					"name" : "Armor Piercing",
+					"units" : "%",
+					"min" : 0
+				},
+				"shield_pierce" : {
+					"name" : "Shield Piercing",
+					"units" : "%",
+					"min" : 0
+				},
+				"weapon_lifesteal" : {
+					"name" : "Weapon Lifesteal",
+					"units" : "%",
+					"min" : 0
+				},
+				"crystal_lifesteal" : {
+					"name" : "Crystal Lifesteal",
+					"units" : "%",
+					"min" : 0
+				}
+			},
+			"abilities" : {
+				"heroic_perk" : {
+					"name" : "Gythian Promise",
+					"thumb" : "gythian-promise.png",
+					"description" : [
+						"After 8s, Anka's next basic attack on an enemy hero becomes an Execute Strike, dealing bonus crystal damage equal to 13%-35% (level 1-12) of the target's missing health.",
+						"Additionally, Anka Fully refreshes Execute Strike and Shimmer Blade upon getting a hero kill or assist."
+					],
+					"stat_levels" : 0,
+					"stats" : false
+				},
+				"a_ability" : {
+					"name" : "Shimmer Blade",
+					"thumb" : "shimmer-blade.png",
+					"description" : [
+						"Anka throws a dagger in the target direction, dealing damage to the first enemy hit. When the dagger hits an enemy, Anka can reactivate the ability within 2.2s to blink next to the victim.", 
+						[
+							"Anka gains a burst of decaying movement speed upon blinking."
+						]
+					],
+					"stat_levels" : 5,
+					"stats" : [
+						{
+							"name" : "Cooldown (s)",
+							"values" : [8, 7.5, 7, 6.5, 6],
+							"ratios" : [0, 0],
+							"overdrive" : false
+						},
+						{
+							"name" : "Energy Cost",
+							"values" : [30, 35, 40, 45, 50],
+							"ratios" : [0, 0],
+							"overdrive" : false
+						},
+						{
+							"name" : "Range (m)",
+							"values" : [8.25, 9, 9.75, 10.5, 12],
+							"ratios" : [0, 0],
+							"overdrive" : 12
+						},
+						{
+							"name" : "Damage",
+							"values" : [35, 60, 85, 110, 160],
+							"ratios" : [50, 0],
+							"overdrive" : 160
+						},
+						{
+							"name" : "Damage (Blink)",
+							"values" : [70, 120, 170, 220, 320],
+							"ratios" : [100, 0],
+							"overdrive" : 320
+						}
+					] 
+				},
+				"b_ability" : {
+					"name" : "Dance of Blades",
+					"thumb" : "dance-of-blades.png",
+					"description" : [
+						"Anka throws five knives in a cone, dealing damage to all enemies the knives pass through.",
+						[
+							"Each additional knife after the first deals damage equal to 50% of the initial damage."
+						]
+					],
+					"stat_levels" : 5,
+					"stats" : [
+						{
+							"name" : "Cooldown (s)",
+							"values" : [7, 6.5, 6, 5.5, 4.5],
+							"ratios" : [0, 0],
+							"overdrive" : 4.5
+						},
+						{
+							"name" : "Energy Cost",
+							"values" : [30, 40, 50, 60, 70],
+							"ratios" : [0, 0],
+							"overdrive" : false
+						},
+						{
+							"name" : "Damage",
+							"values" : [45, 75, 105, 135, 195],
+							"ratios" : [50, 0],
+							"overdrive" : 195
+						}
+					]
+				},
+				"c_ability" : {
+					"name" : "Mirage",
+					"thumb" : "mirage.png",
+					"description" : [
+						"Anka dashes in the target direction and splits off three clones to deceive enemies, dealing damage to enemies they pass through. Her clones dash back to her after 2s, dealing damage to enemies they pass through.",
+						[
+							"Anka is invulnerable and unable to be targeted during her dash.",
+							"Additional pass through deal damage equal to 50% of the initial damage."
+						]
+					],
+					"stat_levels" : 3,
+					"stats" : [
+						{
+							"name" : "Cooldown (s)",
+							"values" : [60, 45, 30],
+							"ratios" : [0, 0],
+							"overdrive" : false
+						},
+						{
+							"name" : "Energy Cost",
+							"values" : [70, 80, 90],
+							"ratios" : [0, 0],
+							"overdrive" : false
+						},
+						{
+							"name" : "Damage (Initial Dash)",
+							"values" : [120, 180, 240],
+							"ratios" : [50, 0],
+							"overdrive" : false
+						},
+						{
+							"name" : "Damage (Returning Dash)",
+							"values" : [240, 360, 480],
+							"ratios" : [100, 0],
+							"overdrive" : false
+						}
+					]
+				}
+			},
+			"builds" : [
+				{
+					"title" : "Ruthless Executioner",
+					"role" : "Carry",
+					"type" : "Crystal",
+					"description" : [
+						"Massive Damage",
+						"Low Defense"
+					],
+					"items" : [
+						"shatterglass",
+						"shatterglass",
+						"broken_myth",
+						"spellfire",
+						"halcyon_chargers",
+						"frostburn"
+					]
+				},
+				{
+					"title" : "Elusive Assassin",
+					"role" : "Carry",
+					"type" : "Crystal",
+					"description" : [
+						"High Mobility",
+						"Moderate Defense"
+					],
+					"items" : [
+						"shatterglass",
+						"clockwork",
+						"broken_myth",
+						"slumbering_husk",
+						"halcyon_chargers",
+						"spellfire"
+					]
+				}
+			]
+		},
 		"ardan" : {
 			"name" : "Ardan",
 			"thumb" : "ardan.png",
@@ -4329,7 +4617,7 @@
 					"level_gain" : 0
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -4653,7 +4941,7 @@
 					"level_gain" : 0.19
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -4824,7 +5112,7 @@
 					"stats" : [
 						{
 							"name" : "Cooldown (s)",
-							"values" : [100, 85, 70],
+							"values" : [80, 65, 50],
 							"ratios" : [0, 0],
 							"overdrive" : false
 						},
@@ -4983,7 +5271,7 @@
 					"level_gain" : 1.03
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -5035,7 +5323,7 @@
 					"description" : [
 						"Baron’s basic attacks deal 130% weapon damage to the target and surrounding enemies.",
 						[
-							"Explosions deal 50% less damage to surrounding enemies.",
+							"Explosions deal 80% damage to surrounding enemies.",
 							"Explosions deal 50% less damage to minions."
 						]
 					],
@@ -5065,7 +5353,7 @@
 						},
 						{
 							"name" : "Energy Cost",
-							"values" : [60, 65, 70, 75, 80],
+							"values" : [60, 60, 60, 60, 60],
 							"ratios" : [0, 0],
 							"overdrive" : false
 						},
@@ -5292,7 +5580,7 @@
 					"level_gain" : 0
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -5458,7 +5746,7 @@
 						{
 							"name" : "Damage",
 							"values" : [80, 120, 160, 200, 240],
-							"ratios" : [180, 100],
+							"ratios" : [180, 120],
 							"overdrive" : false
 						},
 						{
@@ -5655,7 +5943,7 @@
 					"level_gain" : 0.16
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -5974,7 +6262,7 @@
 					"level_gain" : 0.21
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -6273,7 +6561,7 @@
 					"level_gain" : 0.21
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -6324,7 +6612,7 @@
 					"thumb" : "futility-of-life.png",
 					"description" : [
 						[
-							"Whenever chained victims take damage from any source, Churnwalker regenerates 15% of that damage as health.",
+							"Whenever chained victims take damage from any source, Churnwalker regenerates 20% of that damage as health.",
 							"Whenever any chained victim takes damage, 30% of that damage is conferred on all other chained victims."
 						]
 					],
@@ -6347,9 +6635,9 @@
 					"stats" : [
 						{
 							"name" : "Cooldown (s)",
-							"values" : [4, 4, 4, 4, 3],
+							"values" : [4, 3.5, 3, 2.5, 2],
 							"ratios" : [0, 0],
-							"overdrive" : 3
+							"overdrive" : false
 						},
 						{
 							"name" : "Energy Cost",
@@ -6371,9 +6659,9 @@
 						},
 						{
 							"name" : "Damage / Sec (%)",
-							"values" : [1, 1, 1, 1, 2],
+							"values" : [1, 1, 1, 1, 3],
 							"ratios" : [0, 0],
-							"overdrive" : 2
+							"overdrive" : 3
 						}
 					]
 				},
@@ -6563,7 +6851,7 @@
 					"level_gain" : 0.25
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -6723,7 +7011,7 @@
 					"stats" : [
 						{
 							"name" : "Cooldown (s)",
-							"values" : [160, 140, 120],
+							"values" : [120, 100, 80],
 							"ratios" : [0, 0],
 							"overdrive" : false
 						},
@@ -6860,7 +7148,7 @@
 					"level_gain" : 0.15
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -7179,7 +7467,7 @@
 					"level_gain" : 0.13
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -7472,7 +7760,7 @@
 					"level_gain" : 0.21
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -7568,7 +7856,7 @@
 						{
 							"name" : "Bonus Damage",
 							"values" : [20, 40, 60, 80, 120],
-							"ratios" : [100, 25],
+							"ratios" : [100, 15],
 							"overdrive" : 120
 						},
 						{
@@ -7781,7 +8069,7 @@
 					"level_gain" : 0.13
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -7831,7 +8119,7 @@
 					"name" : "Living Armor",
 					"thumb" : "living-armor.png",
 					"description" : [
-						"Each stack of Living Armor reduces incoming damage by 5%.",
+						"Each stack of Living Armor reduces incoming damage by 6%.",
 						[
 							"Grumpjaw gains a stack every 3s and every time he basic attacks.",
 							"While under attack, he loses a stack every 1s.",
@@ -8108,7 +8396,7 @@
 					"level_gain" : 0.15
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -8399,7 +8687,7 @@
 					"level_gain" : 0
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -8719,7 +9007,7 @@
 					"level_gain" : 0.32
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -8787,9 +9075,9 @@
 					"stats" : [
 						{
 							"name" : "Cooldown (s)",
-							"values" : [22, 20, 18, 16, 12],
+							"values" : [20, 18, 16, 14, 10],
 							"ratios" : [0, 0],
-							"overdrive" : 12
+							"overdrive" : 10
 						},
 						{
 							"name" : "Energy Cost",
@@ -9000,7 +9288,7 @@
 					"level_gain" : 0.22
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -9057,7 +9345,7 @@
 						],
 						"Additionally, Kensei's basic attacks deal increased damage to heroes with higher health.",
 						[
-							"Attack Damage: 40% of weapon power + (target max health * 0.022% of bonus weapon power)"
+							"Attack Damage: 40% of weapon power + (target max health * 0.018% of bonus weapon power)"
 						]
 					],
 					"stat_levels" : 0,
@@ -9088,9 +9376,9 @@
 						},
 						{
 							"name" : "Damage (%)",
-							"values" : [55, 55, 55, 55, 65],
+							"values" : [50, 50, 50, 50, 60],
 							"ratios" : [0, 0],
-							"overdrive" : 65
+							"overdrive" : 60
 						},
 						{
 							"name" : "Bonus Damage",
@@ -9298,7 +9586,7 @@
 					"level_gain" : 0
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -9583,9 +9871,9 @@
 				"health_recharge" : {
 					"name" : "Health Recharge",
 					"units" : false,
-					"min" : 0,
-					"max" : 0,
-					"level_gain" : 0
+					"min" : 3.81,
+					"max" : 6.78,
+					"level_gain" : 0.27
 				},
 				"weapon_power" : {
 					"name" : "Weapon Power",
@@ -9634,12 +9922,12 @@
 				"energy_recharge" : {
 					"name" : "Energy Recharge",
 					"units" : false,
-					"min" : 0,
-					"max" : 0,
-					"level_gain" : 0
+					"min" : 3.51,
+					"max" : 6.04,
+					"level_gain" : 0.23
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -9938,7 +10226,7 @@
 					"level_gain" : 0.22
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -10006,9 +10294,9 @@
 					"stats" : [
 						{
 							"name" : "Cooldown (s)",
-							"values" : [8, 7.5, 7, 6.5, 6],
+							"values" : [6, 6, 6, 6, 5],
 							"ratios" : [0, 0],
-							"overdrive" : false
+							"overdrive" : 5
 						},
 						{
 							"name" : "Energy Cost",
@@ -10224,7 +10512,7 @@
 					"level_gain" : 0.17
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -10548,7 +10836,7 @@
 					"level_gain" : 0
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -10602,7 +10890,7 @@
 						"Instead of energy, Lance uses stamina to activate his abilities. Purchasing items with energy and energy regeneration increases his stamina and stamina regeneration.",
 						[
 							"Max Stamina: 100 + 30% Max Energy",
-							"Stamina Regen: 15 + 50% Energy Regen"
+							"Stamina Regen: 20 + 50% Energy Regen"
 						]
 					],
 					"stat_levels" : 0,
@@ -10681,7 +10969,7 @@
 						},
 						{
 							"name" : "Stamina Cost",
-							"values" : [40, 40, 40, 40, 40],
+							"values" : [30, 30, 30, 30, 30],
 							"ratios" : [0, 0],
 							"overdrive" : false
 						},
@@ -10880,7 +11168,7 @@
 					"level_gain" : 0.23
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -11182,7 +11470,7 @@
 					"level_gain" : 0.45
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -11249,7 +11537,7 @@
 					"description" : [
 						"Lyra creates a sigil that heals nearby allied heroes and damages nearby enemy heroes. Reactivate this ability to detonate the sigil, dealing heavy damage to enemies while providing a move speed boost to allies inside and immediately consuming the remaining duration to heal at 30% effectiveness.",
 						[
-							"The healing per second is increase by 11% of Lyra's bonus health.",
+							"The healing per second is increase by 9% of Lyra's bonus health.",
 							"The sigil depletes faster the more heroes it is healing / damaging.",
 							"The sigil has vision, so it can see enemies.",
 							"The Detonation deals 50% less damage to minions."
@@ -11498,7 +11786,7 @@
 					"level_gain" : 0.2
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -11567,7 +11855,7 @@
 					"stats" : [
 						{
 							"name" : "Cooldown (s)",
-							"values" : [14, 13, 12, 11, 10],
+							"values" : [16, 15, 14, 13, 12],
 							"ratios" : [0, 0],
 							"overdrive" : false
 						},
@@ -11604,8 +11892,8 @@
 					"stat_levels" : 5,
 					"stats" : [
 						{
-							"name" : "Cooldown (%)",
-							"values" : [8, 7.5, 7, 6.5, 6],
+							"name" : "Cooldown (s)",
+							"values" : [10, 9.5, 9, 8.5, 8],
 							"ratios" : [0, 0],
 							"overdrive" : false
 						},
@@ -11633,7 +11921,7 @@
 					"stats" : [
 						{
 							"name" : "Cooldown (s)",
-							"values" : [15, 14, 13, 12, 11],
+							"values" : [17, 16, 15, 14, 13],
 							"ratios" : [0, 0],
 							"overdrive" : false
 						},
@@ -11666,7 +11954,7 @@
 					"stat_levels" : 5,
 					"stats" : [
 						{
-							"name" : "Cooldown (%)",
+							"name" : "Cooldown (s)",
 							"values" : [21, 20, 19, 18, 16],
 							"ratios" : [0, 0],
 							"overdrive" : 16
@@ -11864,7 +12152,7 @@
 					"level_gain" : 0
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -12045,7 +12333,7 @@
 					"name" : "Bangarang",
 					"thumb" : "bangarang.png",
 					"description" : [
-						"Ozo charges up, then rolls toward a targeted enemy hero. Upon arrival, Ozo damages, stuns for 0.8s, and flips.",
+						"Ozo charges up, then rolls toward a targeted enemy hero. Upon arrival, Ozo damages, stuns for 0.8s, and flips the target over him.",
 						[
 							"While tumbling, Ozo will damage & knock aside other enemies along his path.",
 							"Max travel duration of 1s."
@@ -12197,7 +12485,7 @@
 					"level_gain" : 0.11
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -12279,7 +12567,7 @@
 						{
 							"name" : "Pet Health",
 							"values" : [100, 180, 260, 340, 500],
-							"ratios" : [50, 0],
+							"ratios" : [65, 0],
 							"overdrive" : 500
 						},
 						{
@@ -12510,7 +12798,7 @@
 					"level_gain" : 0
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -12813,7 +13101,7 @@
 					"level_gain" : 0
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -12969,7 +13257,7 @@
 					"stats" : [
 						{
 							"name" : "Cooldown (s)",
-							"values" : [80, 65, 50],
+							"values" : [60, 50, 40],
 							"ratios" : [0, 0],
 							"overdrive" : false
 						},
@@ -13135,7 +13423,7 @@
 					"level_gain" : 0.21
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -13188,7 +13476,7 @@
 						"Scorcher and Netherform Detonator apply Firestarter to enemy targets.",
 						[
 							"Reza's basic attacks consume Firestarter, dealing crystal damage.",
-							"Crystal Damage: 20-185 (level 1-12) (+115% crystal power)"
+							"Crystal Damage: 20-185 (level 1-12) (+110% crystal power)"
 						]
 					],
 					"stat_levels" : 0,
@@ -13439,7 +13727,7 @@
 					"level_gain" : 0.15
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -13738,7 +14026,7 @@
 					"level_gain" : 0
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -13926,7 +14214,7 @@
 					"stats" : [
 						{
 							"name" : "Cooldown (s)",
-							"values" : [8, 8, 8],
+							"values" : [6, 6, 6],
 							"ratios" : [0, 0],
 							"overdrive" : false
 						},
@@ -13938,7 +14226,7 @@
 						},
 						{
 							"name" : "Damage / Sec",
-							"values" : [225, 325, 425],
+							"values" : [250, 350, 450],
 							"ratios" : [120, 160],
 							"overdrive" : false
 						},
@@ -13950,7 +14238,7 @@
 						},
 						{
 							"name" : "Fortify / Second",
-							"values" : [60, 90, 120],
+							"values" : [60, 100, 140],
 							"ratios" : [0, 0],
 							"overdrive" : false
 						}
@@ -14074,7 +14362,7 @@
 					"level_gain" : 0.45
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -14193,7 +14481,7 @@
 					"stats" : [
 						{
 							"name" : "Cooldown (s)",
-							"values" : [23, 23, 23, 23, 23],
+							"values" : [26, 26, 26, 26, 26],
 							"ratios" : [0, 0],
 							"overdrive" : false
 						},
@@ -14390,7 +14678,7 @@
 					"level_gain" : 0.11
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -14716,7 +15004,7 @@
 					"level_gain" : 0.16
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -14967,8 +15255,8 @@
 				"health" : {
 					"name" : "Health",
 					"units" : false,
-					"min" : 668,
-					"max" : 2060,
+					"min" : 708,
+					"max" : 2100,
 					"level_gain" : 126.54
 				},
 				"health_recharge" : {
@@ -15040,7 +15328,7 @@
 					"min" : 3.2
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -15354,7 +15642,7 @@
 					"level_gain" : 0.16
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -15516,7 +15804,7 @@
 						{
 							"name" : "Damage",
 							"values" : [250, 350, 450],
-							"ratios" : [150, 100],
+							"ratios" : [150, 120],
 							"overdrive" : false
 						},
 						{
@@ -15668,7 +15956,7 @@
 					"level_gain" : 0.22
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -15956,7 +16244,7 @@
 					"level_gain" : 2.6
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -16280,7 +16568,7 @@
 					"level_gain" : 0.16
 				},
 				"cooldown" : {
-					"name" : "Cooldown Speed",
+					"name" : "Cooldown Reduction",
 					"units" : "%",
 					"min" : 100
 				},
@@ -16350,7 +16638,7 @@
 					"stats" : [
 						{
 							"name" : "Cooldown (s)",
-							"values" : [6, 5.5, 5, 4.5, 4],
+							"values" : [7, 6.5, 6, 5.5, 5],
 							"ratios" : [0, 0],
 							"overdrive" : false
 						},
@@ -16362,9 +16650,9 @@
 						},
 						{
 							"name" : "Basic Attack Damage (%)",
-							"values" : [50, 50, 50, 50, 60],
+							"values" : [60, 60, 60, 60, 70],
 							"ratios" : [0, 0],
-							"overdrive" : 60
+							"overdrive" : 70
 						}
 					]
 				},


### PR DESCRIPTION
##### Tasks done for this update:

###### Hero Updates:
  * Changed phrase "Cooldown Speed" to "Cooldown Reduction" in all cases
  * Added all of the new hero base data for the new hero "Anka"
  * Added images for Anka and her abilities/perk
  * Added in Kinetic's Energy Recharge and Health Recharge data
  * Updated Adagio's GIFT OF FIRE
    * Fire Damage Per Second 20/30/40/50/70 → 10/20/30/40/60
    * Crystal Ratio 20% → 25%
    * Health Ratio 12% → 9%
  * Updated Alpha's STATS
    * Health 761-2438 → 761-2537
    * Attack Speed 100%-122% → 100-136.3%
  * Updated Baptiste's FEARSOME SHADE
    * Cooldown 100/85/70 → 80/65/50
  * Updated Baron's ROCKET LAUNCHER
    * Splash Damage 50% → 80%
  * Updated Baron's PORCUPINE MORTAR
    * Energy Cost 60/65/70/75/80 → 60/60/60/60/60
  * Updated Blackfeather's ON POINT
    * Weapon Ratio 100% → 120%
  * Updated Churnwalker's FUTILITY OF LIFE
    * Chain Healing 15% → 20%
  * Updated Churnwalker's HOOK & CHAIN
    * Cooldown 4/4/4/4/3 → 4/3.5/3/2.5/2
    * Damage Per Second 1/1/1/1/2% → 1/1/1/1/3%
  * Updated Flicker's MOONCLOAK
    * Cooldown 160/140/120 → 120/100/80
  * Updated Grace's RETRIBUTION
    * Weapon Ratio 10% → 5%
    * Base Damage 10-142 → 10-98
  * Updated Grace's BENEDICTION
    * Weapon Ratio 0% (Was Bugged) → 15%
  * Updated Grumpjaw's LIVING ARMOR
    * Damage Reduction 5% → 6%
  * Updated Joule's ROCKET LEAP
    * Cooldown 22/20/18/16/12 → 20/18/16/14/10
  * Updated Kensei's IMMOVABLE MIND
    * Weapon Ratio 0.022% →  0.018%
  * Updated Kensei's LOTUS STRIKE
    * Damage 55/55/55/55/65% → 50/50/50/50/60%
  * Updated Kestrel's perk language
  * Updated Koshka's POUNCY FUN
    * Cooldown 8/7.5/7/6.5/6 → 6/6/6/6/5
  * Updated Lance's PARTISAN’S TECHNIQUE
    * Stamina Generation Per Second 15 → 20
  * Updated Lance's GYTHIAN WALL
    * Stamina Cost 40 → 30
  * Updated Lyra's IMPERIAL SIGIL
    * Health Ratio 12% → 9%
  * Updated Malene's LIGHT RIBBONS
   * Cooldown 14/13/12/11/10 → 16/15/14/13/12
  * Updated Malene's SHADOW TENDRILS
    * Cooldown 8/7.5/7/6.5/6 → 10/9.5/9/8.5/8
  * Updated Malene's ROYAL AMNESTY
    * Cooldown 15/14/13/12/11 → 17/16/15/14/13
  * Updated Ozo's BANGARANG language
  * Updated Petal's BRAMBLEBOOM SEEDS
    * Pet Health Crystal Ratio 50% → 65%
  * Updated Reim's VALKYRIE
    * Cooldown 80/65/50 → 60/50/40
  * Updated Reza's FIRESTARTER
    * Crystal Ratio 115% → 110%
  * Updated Rona's INTO THE FRAY
    * Rupture Damage (Minions) 40/70/100/130/220 + 100% CP  → 50% of Rupture Damage
  * Updated Rona's RED MIST
    * Cooldown 8 → 6
    * Damage Per Second 225/325/425 → 250/350/450
    * Fortified Life Generation Per Second 60/90/120 → 60/100/140
  * Updated Samuel's DRIFTING DARK
    * Cooldown 23/23/23/23/23 → 26/26/26/26/26
  * Updated Skye's STATS
    * Health 668-2060 → 708-2100
  * Updated Taka's X-RETSU
    * Weapon Ratio 100% → 120%
  * Updated Vox's SONIC ZOOM
    * Cooldown 6/5.5/5/4.5/4 → 7/6.5/6/5.5/5
    * Damage 50/50/50/50/60% → 60/60/60/60/70%

###### Item Updates:
  * Updated BOOK OF EULOGIES
    * Melee Healing 60 → 65
  * Updated CAPACITOR PLATE
    * Healing Amplification 20% → 15%
  * Updated COAT OF PLATES
    * Price 550 → 500
  * Updated EVE OF HARVEST
    * Crystal Power 55 → 70
  * Updated KINETIC SHIELD
    * Price 550 → 500
  * Updated LIGHT ARMOR
    * Armor 30 → 35
    * Price 250 → 300
  * Updated LIGHT SHIELD
    * Shield 30 → 35
    * Price 250 → 300
  * Updated LUCKY STRIKE
    * Critical Chance 20% → 25%
    * Critical Damage 8% → 5%
  * Updated POISONED SHIV
    * Attack Damage 40 → 30
  * Updated PULSEWEAVE
    * Base Slow Strength 25% → 20%
    * Slow Health Scaling 0.015% → 0.01%
  * Updated SPELLFIRE
    * Burn Damage 8-30 → 5-20
  * Updated TORNADO TRIGGER
    * Attack Speed 40% → 30%
    * Critical Damage 0 → 5%